### PR TITLE
Respects plugin config options

### DIFF
--- a/src/coffeescript.plugin.coffee
+++ b/src/coffeescript.plugin.coffee
@@ -17,6 +17,7 @@ module.exports = (BasePlugin) ->
 			{content} = opts
 			coffee = require('coffee-script')
 
+			# Needs to be a deep clone because coffee modifies the object passed
 			config = JSON.parse JSON.stringify @config
 
 			# Render


### PR DESCRIPTION
I needed ability to generate bare JS files for my project and found out that plugin config in `docpad.coffee` arent used in the coffee compiler. Here's a fix.
