### PR TITLE
Embedded sourcemap support

### DIFF
--- a/src/coffeescript.plugin.coffee
+++ b/src/coffeescript.plugin.coffee
@@ -26,13 +26,11 @@ module.exports = (BasePlugin) ->
 					sourceFiles: [file.get('url') + '.coffee'] # but actually included inline
 					generatedFile: file.get('url')
 					literate: literate or coffee.helpers.isLiterate(fileFullPath)
-					sourceMap: false
 				}
 
 				# Merge options
 				for own key,value of @getConfig().compileOptions
-					if compileOptions[key]?
-						compileOptions[key] = value
+					compileOptions[key] ?= value
 
 				# Render
 				try


### PR DESCRIPTION
I wanted to have a go at fixing #6, and started down the road of outputting the sourcemap to a .map file. It would have also probably needed outputting the original coffeescript source somewhere as well. I tried to copy the approach of [docpad-plugin-combiner](https://github.com/pflannery/docpad-plugin-combiner/blob/master/src/combiner.plugin.coffee#L91-L106), but quickly ran into bevry/docpad#765 style issues.

Luckily, the V3 standard allows embedding the original source within the sourcemap, and [coffeescript](http://coffeescript.org/documentation/docs/browser.html#section-5) already does the data-url trick to embed the sourcemap under some circumstances anyway, so I followed that approach. The advantage is that everything is still one file being rendered into another that way. The disadvantage is that it bloats the generated .js, so, it should be limited to development, but then I configure like this anyway:

``` coffeescript
docpadConfig = {
    [...]
    environments:
      development:
        plugins:
          coffeescript:
            compileOptions:
              sourceMap: true
}
```

Even though the source is embedded, the browser still wants a nominal URL that the source is from. I went with `{url}.coffee` so, in the browser debugger, the .js.coffee shows in the same path as the actually-executed .js file.

And that's about it. Works pretty well!
